### PR TITLE
#1 Inconsistent Sidebar Styles 

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Issue #1 Inconsistent Sidebar Styles
I changed the class name for the h3 tag from sidebar_title to sidebar-title in the publify_core/app/views/archives_sidebar/_content.html.erb file.
The sidebar-title class has the font-family as monospace and the sidebar-body li has the list-style-type as circle. So added those classes to the respective divs to get the desired changes