### PR TITLE
replaced underscore with dash to match class name in style.css

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
issue #1 Inconsistent Sidebar Styles

inspected the styles for sidebar and noticed 'Archives' was inheriting 'Helvetica Neue' font from bootstrap.css line 883 for body instead of from style.css line 81 for class sidebar-title. 'Tags' was not inheriting the same style. 

after looking at the view files in publify_core directory with files for 'tags' and 'archives' side by side, I noticed the subtle difference which I was not able to see when I was comparing the difference between the two in the browser console.