### PR TITLE
fixes#1, updated sidebar class to match monospace css.

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
**Inconsistent Sidebar Styles #1**

- Publify Version: 8.3.3
- Page(s) the bug occurs: `publify_core/app/views/archives_sidebar/_content.html.erb`

**Reproducing Error**
1. After logging in and creating post.
2. proceed to localhost:3000 and view the article
3. on the right side observe the font for Archives differs from the other headers
4. on the right side observe that the bullet points under archives are filled circles
![screen shot 2017-07-20 at 11 06 17 am](https://user-images.githubusercontent.com/25750397/28433020-1aa0dbba-6d3f-11e7-9b15-8754dc595fb8.png)

**Environment settings and versions**
1. Ruby = 2.2.5

**Debugging and resolving issue**
Using chrome dev tools, checked the sidebar for differences between titles and list items that were inheriting the monospace and not inheriting monospace.  Checked css classes, noticed that monospace was being applied to `#sidebar .sidebar-title` and `#sidebar .sidebar-body li`. **Archives** was not inheriting monospace because its classes had a `_` instead of a `-`.  Went to `_content.html.erb` and updated:
```
 <h3 class="sidebar_title"><%= sidebar.title %></h3>
  <div class="sidebar_body">
```
to 

```
 <h3 class="sidebar-title"><%= sidebar.title %></h3>
  <div class="sidebar-body">
```
![screen shot 2017-07-20 at 11 49 54 am](https://user-images.githubusercontent.com/25750397/28433731-9dc5a460-6d41-11e7-8373-d97f686ce527.png)

fixes#1



