### PR TITLE
Corrected tags not being saved properly

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
Function save_article_tags in the publify_admin.js file was not properly capturing the value of the tag input. Added .val() method to capture the value and pass it along to be displayed in the articles view. 

Resolves issue #2 