### PR TITLE
Fix spinner to hide after AJAX call

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
-  $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $(document).on('ajaxStart', function(evt, xhr, status){ $('#spinner').show();})
+  $(document).on('ajaxStop', function(evt, xhr, status){ $('#spinner').hide();})
 });


### PR DESCRIPTION
Spinner wouldn't hide after AJAX call was completed. Found [[https://stackoverflow.com/questions/18499449/show-ajax-spinner-hide-page-render-until-all-ajax-calls-complete| this ]](url) code on stack overflow. Following the code in the accepted answer I changed the target from form.spinnable to document and used ajaxStart and ajaxStop to properly show and hide the spinner gif. 

Resolves issue #3 