### PR TITLE
fixes#2, post tags are shown as "object" 

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val);
 }
 
 function doneTyping () {
@@ -113,7 +113,7 @@ function check_all(checkbox) {
 
 $(document).ready(function() {
   $('#article_form').each(function(e){autosave_request(e)});
-  $('#article_form').submit(function(e){save_article_tags()});
+  $('#article_form').each(function(e){save_article_tags()});
   $('#article_form').each(function(e){tag_manager()});
   $('#article_form').each(function(e){set_widerea($('#article_body_and_extended'))});
   $('#article_body_and_extended').each(function(e){set_savebar()});

--- a/publify_core/app/assets/javascripts/tagmanager.js
+++ b/publify_core/app/assets/javascripts/tagmanager.js
@@ -436,11 +436,11 @@
                         $self.focus();
                     } // why?
 
-                    /* unimplemented mode to push tag on blur
+                    //  unimplemented mode to push tag on blur
                      else if (tagManagerOptions.pushTagOnBlur) {
-                     console.log('change: pushTagOnBlur ' + tag);
+                    //  console.log('change: pushTagOnBlur ' + tag);
                      pushTag($(this).val());
-                     } */
+                   }
                     privateMethods.killEvent(e);
                 });
 

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
**post tags are shown as "object" #2**
- Publify Version: 8.3.3
- Page(s) the bug occurs: `publify_core/app/assets/javascripts/publify_admin.js` and `publify_core/app/assets/javascripts/tagmanager.js
`

After creating a post one can see that the posts tags, regardless of what was entered are shown as "object".

**Steps to reproduce:**
1. Create a new post
2. When you press publish, enter some tags (quantity doesn't seem to matter)
3. Finish publishing the post
4. Visit the root route
5. Observe the newest post has tags "object object"

**Expected behavior:**
the tags one types are displayed in the article summary
![screen shot 2017-07-20 at 11 56 48 am](https://user-images.githubusercontent.com/25750397/28450983-963148a4-6d9f-11e7-9dcd-c9ccbcb85e90.png)

**Resolved post tag issue by:** 

Adding .val to the end `save_article_tags` to save tag input values. 
```
Before:
$('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
After:
$('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val);
```

Changed .`submit` in  `$(document).ready(function()` to `.each` to remove [object Object] from input fields.
```
$('#article_form').submit(function(e){save_article_tags()});
$('#article_form').each(function(e){save_article_tags()});
```

Initiated unused `blur ` function to allow multiple tags to display.
```
 //unimplemented mode to push tag on blur
   else if (tagManagerOptions.pushTagOnBlur) {
   console.log('change: pushTagOnBlur ' + tag);
   pushTag($(this).val());
}
```

![screen shot 2017-07-20 at 11 19 42 pm](https://user-images.githubusercontent.com/25750397/28451412-f9ddb9d0-6da1-11e7-8c85-52c16a11b94c.png)

fixes#2

